### PR TITLE
List methods

### DIFF
--- a/cli/policy.go
+++ b/cli/policy.go
@@ -22,7 +22,7 @@ import (
 )
 
 type policyCommonOptions struct {
-	project string
+	project   string
 	projectId string
 }
 
@@ -32,11 +32,11 @@ type policyOpOptions struct {
 
 type policyListOptions struct {
 	allTenants bool
-	detail bool
+	detail     bool
 }
 
 type policyAttachOptions struct {
-	policy string
+	policy  string
 	network string
 }
 
@@ -44,22 +44,22 @@ type policyProtocolValue string
 type policyPortValue int
 
 var protocolValues = map[string]int{
-	"tcp": 6,
-	"udp": 17,
+	"tcp":  6,
+	"udp":  17,
 	"icmp": 1,
-	"any": 0,
+	"any":  0,
 }
 
 type policyRuleOptions struct {
-	ruleId string
-	afterRule string
-	policy string
+	ruleId       string
+	afterRule    string
+	policy       string
 	srcIpAddress string
-	srcNetwork string
+	srcNetwork   string
 	dstIpAddress string
-	dstNetwork string
-	protocol policyProtocolValue
-	srcPort policyPortValue
+	dstNetwork   string
+	protocol     policyProtocolValue
+	srcPort      policyPortValue
 	// srcPortRange string
 	dstPort policyPortValue
 	// dstPortRange string
@@ -72,9 +72,9 @@ type policyRuleOptions struct {
 
 var (
 	policyCommonOpts policyCommonOptions
-	policyOpOpts policyOpOptions
-	policyListOpts policyListOptions
-	policyRuleOpts policyRuleOptions
+	policyOpOpts     policyOpOptions
+	policyListOpts   policyListOptions
+	policyRuleOpts   policyRuleOptions
 	policyAttachOpts policyAttachOptions
 )
 
@@ -101,13 +101,13 @@ const policyShowDetail = `  Policy: {{.GetName}}
 // Retrieves the virtual-network references from the policy rules
 // for display purposes.
 func getRulesNetworks(policy *types.NetworkPolicy) (string, string) {
-	displayValue := func (m map[string]bool) string {
+	displayValue := func(m map[string]bool) string {
 		if len(m) > 1 {
 			return "<multiple>"
 		}
 		for key, _ := range m {
 			fqn := strings.Split(key, ":")
-			return fqn[len(fqn) - 1]
+			return fqn[len(fqn)-1]
 		}
 		return "none"
 	}
@@ -133,7 +133,7 @@ func getRulesNetworks(policy *types.NetworkPolicy) (string, string) {
 // Summary information of the network policies configured (per project)
 func policyListTerse(client *contrail.Client, projectId string) {
 	poList, err := client.ListDetailByParent(
-		"network-policy", projectId, nil, 0)
+		"network-policy", projectId, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
@@ -165,7 +165,7 @@ func makeShowTemplate() *template.Template {
 func policyListDetail(client *contrail.Client, projectId string) {
 	poList, err := client.ListDetailByParent(
 		"network-policy", projectId,
-		[]string{"virtual_network_back_refs"}, 0)
+		[]string{"virtual_network_back_refs"})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -184,7 +184,7 @@ func policyList(client *contrail.Client, flagSet *flag.FlagSet) {
 	if !policyListOpts.allTenants {
 		var err error
 		projectId, err = config.GetProjectId(
-			client,	policyCommonOpts.project,
+			client, policyCommonOpts.project,
 			policyCommonOpts.projectId)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -294,7 +294,7 @@ func getPolicyObject(
 
 func getPolicyId(client *contrail.Client,
 	projectName, projectId, policyNameOrId string) (
-		string, error) {
+	string, error) {
 
 	uuid := strings.ToLower(policyNameOrId)
 	if !config.IsUuid(uuid) {
@@ -321,15 +321,15 @@ func makeAddresses(optAddress, optNetwork string) []types.AddressType {
 		comp := strings.Split(optAddress, "/")
 		if len(comp) != 2 {
 			fmt.Fprintf(os.Stderr,
-				"Expected IP prefix in the format n.n.n.n/n" +
-				", got %s\n", optAddress)
+				"Expected IP prefix in the format n.n.n.n/n"+
+					", got %s\n", optAddress)
 			os.Exit(2)
 		}
 		matched, _ := regexp.MatchString(config.IpAddressPattern,
 			comp[0])
 		if !matched {
 			fmt.Fprintf(os.Stderr, "Invalid IP address: %s\n",
-			comp[0])
+				comp[0])
 			os.Exit(2)
 		}
 		address.Subnet.IpPrefix = comp[0]
@@ -394,11 +394,11 @@ func policyRuleAdd(client *contrail.Client, flagSet *flag.FlagSet) {
 	entries := policy.GetNetworkPolicyEntries()
 	rule := makePolicyRule(&policyRuleOpts)
 
-	insertRule := func (list []types.PolicyRuleType, i int,
+	insertRule := func(list []types.PolicyRuleType, i int,
 		rule *types.PolicyRuleType) []types.PolicyRuleType {
-			return append(list[:i+1],
-				append([]types.PolicyRuleType{*rule},
-					list[i+1:]...)...)
+		return append(list[:i+1],
+			append([]types.PolicyRuleType{*rule},
+				list[i+1:]...)...)
 	}
 	if uuid := policyRuleOpts.afterRule; len(uuid) > 0 {
 		matched, _ := regexp.MatchString(config.UuidPattern, uuid)
@@ -409,7 +409,7 @@ func policyRuleAdd(client *contrail.Client, flagSet *flag.FlagSet) {
 		var ok bool
 		for i, entry := range entries.PolicyRule {
 			if entry.RuleUuid == uuid {
-				entries.PolicyRule = 
+				entries.PolicyRule =
 					insertRule(entries.PolicyRule, i, rule)
 				ok = true
 				break
@@ -502,16 +502,15 @@ func policyRuleDelete(client *contrail.Client, flagSet *flag.FlagSet) {
 		os.Exit(2)
 	}
 
-	deleteRule := func (list []types.PolicyRuleType, i int) (
-		[]types.PolicyRuleType) {
-			return append(list[:i], list[i+1:]...)
+	deleteRule := func(list []types.PolicyRuleType, i int) []types.PolicyRuleType {
+		return append(list[:i], list[i+1:]...)
 	}
 
 	var ok bool
 	entries := policy.GetNetworkPolicyEntries()
 	for i, entry := range entries.PolicyRule {
 		if entry.RuleUuid == uuid {
-			entries.PolicyRule = 
+			entries.PolicyRule =
 				deleteRule(entries.PolicyRule, i)
 			ok = true
 			break

--- a/cli/virtual_router.go
+++ b/cli/virtual_router.go
@@ -20,7 +20,7 @@ import (
 )
 
 type virtualRouterListOptions struct {
-	detail bool
+	detail          bool
 	analyticsServer string
 }
 
@@ -29,16 +29,16 @@ type virtualRouterCreateOptions struct {
 }
 
 var (
-	virtualRouterListOpts virtualRouterListOptions
+	virtualRouterListOpts   virtualRouterListOptions
 	virtualRouterCreateOpts virtualRouterCreateOptions
 )
 
 type virtualRouterInfo struct {
-	Name string
-	IpAddress string
-	Configured bool		// In config DB
-	Present bool		// Reported by analytics DB
-	Status string		// Analytics NodeStatus query result
+	Name       string
+	IpAddress  string
+	Configured bool   // In config DB
+	Present    bool   // Reported by analytics DB
+	Status     string // Analytics NodeStatus query result
 }
 
 const virtualRouterShowDetail = `  Name: {{.Name}}
@@ -58,7 +58,7 @@ func virtualRouterAnalyticsStatus(client *contrail.Client,
 		server = client.GetServer()
 	}
 	api := analytics.NewAnalyticsClient(
-		server,	analytics.AnalyticsDefaultPort)
+		server, analytics.AnalyticsDefaultPort)
 
 	routers, err := api.VirtualRouterList()
 	if err != nil {
@@ -85,7 +85,7 @@ func virtualRouterAnalyticsStatus(client *contrail.Client,
 func virtualRouterList(client *contrail.Client, flagSet *flag.FlagSet) {
 	var fields []string
 	detail := virtualRouterListOpts.detail
-	routerList, err := client.ListDetail("virtual-router", fields, 0)
+	routerList, err := client.ListDetail("virtual-router", fields)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -96,8 +96,8 @@ func virtualRouterList(client *contrail.Client, flagSet *flag.FlagSet) {
 	for _, obj := range routerList {
 		router := obj.(*types.VirtualRouter)
 		routerMap[router.GetName()] = &virtualRouterInfo{
-			Name: router.GetName(),
-			IpAddress: router.GetVirtualRouterIpAddress(),
+			Name:       router.GetName(),
+			IpAddress:  router.GetVirtualRouterIpAddress(),
 			Configured: true,
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 	"unicode"
 )
@@ -55,10 +54,10 @@ type ApiClient interface {
 	UuidByName(typename string, fqn string) (string, error)
 	FQNameByUuid(uuid string) ([]string, error)
 	FindByName(typename string, fqn string) (IObject, error)
-	List(typename string, count int) ([]ListResult, error)
-	ListByParent(typename string, parent_id string, count int) ([]ListResult, error)
-	ListDetail(typename string, fields []string, count int) ([]IObject, error)
-	ListDetailByParent(typename string, parent_id string, fields []string, count int) ([]IObject, error)
+	List(typename string) ([]ListResult, error)
+	ListByParent(typename string, parent_id string) ([]ListResult, error)
+	ListDetail(typename string, fields []string) ([]IObject, error)
+	ListDetailByParent(typename string, parent_id string, fields []string) ([]IObject, error)
 }
 
 // A client of the OpenContrail API server.
@@ -444,14 +443,11 @@ func (c *Client) FindByName(typename string, fqn string) (IObject, error) {
 
 // Retrieve the list of all elements of a specific type.
 func (c *Client) ListByParent(
-	typename string, parent_id string, count int) ([]ListResult, error) {
+	typename string, parent_id string) ([]ListResult, error) {
 	var values url.Values
 	values = make(url.Values, 0)
 	if len(parent_id) > 0 {
 		values.Add("parent_id", parent_id)
-	}
-	if count > 0 {
-		values.Add("count", strconv.Itoa(count))
 	}
 
 	url := fmt.Sprintf("http://%s:%d/%ss", c.server, c.port, typename)
@@ -488,12 +484,12 @@ func (c *Client) ListByParent(
 	return rlist, err
 }
 
-func (c *Client) List(typename string, count int) ([]ListResult, error) {
-	return c.ListByParent(typename, "", 0)
+func (c *Client) List(typename string) ([]ListResult, error) {
+	return c.ListByParent(typename, "")
 }
 
 func (c *Client) ListDetailByParent(
-	typename string, parent_id string, fields []string, count int) (
+	typename string, parent_id string, fields []string) (
 	[]IObject, error) {
 	var values url.Values
 	values = make(url.Values, 0)
@@ -502,9 +498,6 @@ func (c *Client) ListDetailByParent(
 	}
 	for _, field := range fields {
 		values.Add("fields", field)
-	}
-	if count > 0 {
-		values.Add("count", strconv.Itoa(count))
 	}
 	values.Add("detail", "true")
 
@@ -570,9 +563,9 @@ func (c *Client) ListDetailByParent(
 	return result, nil
 }
 
-func (c *Client) ListDetail(typename string, fields []string, count int) (
+func (c *Client) ListDetail(typename string, fields []string) (
 	[]IObject, error) {
-	return c.ListDetailByParent(typename, "", fields, count)
+	return c.ListDetailByParent(typename, "", fields)
 }
 
 // Retrieve a specified field of an object from the API server.

--- a/config/network.go
+++ b/config/network.go
@@ -81,7 +81,7 @@ func NetworkList(client contrail.ApiClient, project_id string, detail bool) (
 		fields = append(fields, "network_policys")
 	}
 	networks, err := client.ListDetailByParent(
-		"virtual-network", project_id, fields, 0)
+		"virtual-network", project_id, fields)
 	if err != nil {
 		return nil, err
 	}

--- a/mocks/client_test.go
+++ b/mocks/client_test.go
@@ -1,0 +1,58 @@
+package mocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Juniper/contrail-go-api/types"
+)
+
+func TestUpdateClearVM(t *testing.T) {
+	client := new(ApiClient)
+	client.Init()
+
+	project := new(types.Project)
+	project.SetFQName("domain", []string{"default-domain", "tenant"})
+	assert.NoError(t, client.Create(project))
+
+	vm := new(types.VirtualMachine)
+	vm.SetFQName("project", []string{"default-domain", "tenant", "instance"})
+	assert.NoError(t, client.Create(vm))
+
+	vmi := new(types.VirtualMachineInterface)
+	vmi.SetFQName("project", []string{"default-domain", "tenant", "instance"})
+	vmi.AddVirtualMachine(vm)
+	assert.NoError(t, client.Create(vmi))
+
+	vmi.ClearVirtualMachine()
+	assert.NoError(t, client.Update(vmi))
+
+	assert.NoError(t, client.Delete(vm))
+}
+
+func TestListByParent(t *testing.T) {
+	client := new(ApiClient)
+	client.Init()
+
+	projectNames := []string{"p1", "p2", "p3"}
+	vmNames := []string{"a", "b", "c", "d"}
+
+	for _, projectName := range projectNames {
+		project := new(types.Project)
+		project.SetFQName("domain", []string{"default-domain", projectName})
+		assert.NoError(t, client.Create(project))
+
+		for _, vmName := range vmNames {
+			vm := new(types.VirtualMachine)
+			vm.SetFQName("project", []string{"default-domain", projectName, vmName})
+			assert.NoError(t, client.Create(vm))
+		}
+	}
+
+	elements, err := client.ListByParent("virtual-machine", "default-domain:p2")
+	assert.NoError(t, err)
+	for _, element := range elements {
+		assert.Equal(t, "p2", element.Fq_name[1])
+	}
+}

--- a/mocks/database.go
+++ b/mocks/database.go
@@ -15,7 +15,7 @@ type Database interface {
 	Delete(obj contrail.IObject) error
 	GetByUuid(id uuid.UUID) (contrail.IObject, error)
 	GetByName(typename string, fqn string) (contrail.IObject, error)
-	// List(typename string, start uuid.UUID, count int) ([]contrail.IObject, uuid.UUID)
+	List(typename string) []contrail.IObject
 	GetChildren(uid UID, typename string) (UIDList, error)
 	GetBackReferences(uid UID, typename string) (UIDList, error)
 }
@@ -265,10 +265,10 @@ func (db *InMemDatabase) Delete(obj contrail.IObject) error {
 		return fmt.Errorf("Object %s: not in database", obj.GetUuid())
 	}
 	if len(data.children) > 0 {
-		return fmt.Errorf("Delete %s: has children %+v", data.children)
+		return fmt.Errorf("Delete %s: has children %+v", obj.GetUuid(), data.children)
 	}
 	if len(data.backRefs) > 0 {
-		return fmt.Errorf("Delete %s: has references %+v", data.backRefs)
+		return fmt.Errorf("Delete %s: has references %+v", obj.GetUuid(), data.backRefs)
 	}
 
 	if !data.parent.IsNIL() {
@@ -335,4 +335,19 @@ func (db *InMemDatabase) GetBackReferences(uid UID, typename string) (UIDList, e
 		return nilList, nil
 	}
 	return refList, nil
+}
+
+func (db *InMemDatabase) List(typename string) []contrail.IObject {
+	nilList := []contrail.IObject{}
+	typeMap, ok := db.typeDB[typename]
+	if !ok {
+		return nilList
+	}
+	values := make([]contrail.IObject, len(typeMap))
+	i := 0
+	for _, v := range typeMap {
+		values[i] = v
+		i++
+	}
+	return values
 }

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -1,15 +1,15 @@
 package contrail
 
 import (
+	"fmt"
 	"github.com/Juniper/contrail-go-api"
 	"github.com/Juniper/contrail-go-api/types"
-	"fmt"
 	"testing"
 )
 
 func TestClient(t *testing.T) {
 	client := contrail.NewClient("localhost", 8082)
-	elements, err := client.List("project", 0)
+	elements, err := client.List("project")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestCreate(t *testing.T) {
 	subnets := types.VnSubnetsType{}
 	subnets.AddIpamSubnets(
 		&types.IpamSubnetType{
-			Subnet: types.SubnetType{"10.0.0.0", 8}})
+			Subnet: &types.SubnetType{"10.0.0.0", 8}})
 	net.AddNetworkIpam(ipam.(*types.NetworkIpam), subnets)
 	err = client.Create(&net)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestReferenceUpdate(t *testing.T) {
 	subnets := types.VnSubnetsType{}
 	subnets.AddIpamSubnets(
 		&types.IpamSubnetType{
-			Subnet: types.SubnetType{"10.0.0.0", 8}})
+			Subnet: &types.SubnetType{"10.0.0.0", 8}})
 	net.AddNetworkIpam(ipam.(*types.NetworkIpam), subnets)
 	err = client.Create(&net)
 	if err != nil {
@@ -164,8 +164,7 @@ func TestReferenceUpdate(t *testing.T) {
 		nsubnets := types.VnSubnetsType{}
 		nsubnets.AddIpamSubnets(
 			&types.IpamSubnetType{
-				Subnet: types.SubnetType{
-					"192.168.0.0", 16}})
+				Subnet: &types.SubnetType{"192.168.0.0", 16}})
 		netPtr.AddNetworkIpam(ipam.(*types.NetworkIpam), nsubnets)
 		client.Update(netPtr)
 	} else {
@@ -215,7 +214,7 @@ func TestReferenceUpdate(t *testing.T) {
 
 func TestListDetail(t *testing.T) {
 	client := contrail.NewClient("localhost", 8082)
-	objects, err := client.ListDetail("virtual-network", nil, 0)
+	objects, err := client.ListDetail("virtual-network", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +228,7 @@ func TestListDetail(t *testing.T) {
 		objectMap[net.GetName()] = net
 	}
 
-	expected := []string {
+	expected := []string{
 		"ip-fabric", "__link_local__",
 	}
 	for _, expect := range expected {


### PR DESCRIPTION
Implement List methods on ApiClient mock.

Remove "count" argument from List methods. The URL parameter count is used
to retrieve the number of entries in the database, not for iteration purposes.
