### PR TITLE
Make IObject really public by exporting objectInterface

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,9 +26,9 @@ import (
 // Each auto-generated type implements the IObject interface.
 type TypeMap map[string]reflect.Type
 
-// objectInterface defines the interface used internally between
+// ObjectInterface defines the interface used internally between
 // ObjectBase and Client implmementation
-type objectInterface interface {
+type ObjectInterface interface {
 	GetField(IObject, string) error
 	UpdateReference(*ReferenceUpdateMsg) error
 }
@@ -107,7 +107,11 @@ func (c *Client) SetAuthenticator(auth Authenticator) {
 }
 
 func typename(ptr IObject) string {
-	name := reflect.TypeOf(ptr).Elem().Name()
+	tname := reflect.TypeOf(ptr)
+	if tname.Kind() == reflect.Ptr {
+		tname = tname.Elem()
+	}
+	name := tname.Name()
 	var buf []rune
 	for i, c := range name {
 		if unicode.IsUpper(c) {

--- a/object.go
+++ b/object.go
@@ -27,7 +27,7 @@ type IObject interface {
 	SetUuid(string)
 	SetFQName(string, []string)
 
-	SetClient(objectInterface)
+	SetClient(ObjectInterface)
 	UpdateObject() ([]byte, error)
 	UpdateReferences() error
 	UpdateDone()
@@ -45,7 +45,7 @@ type ObjectBase struct {
 
 	// clientPtr is set once the object is persisted in the API server
 	// or for objects that are retrieved via Read/GET
-	clientPtr objectInterface
+	clientPtr ObjectInterface
 	parent    IObject
 }
 
@@ -123,7 +123,7 @@ func (obj *ObjectBase) GetParentType() string {
 
 // SetClient is used to mark an object as persistent (it has been created or read)
 // from the API and supplying it with the methods required to perform an update.
-func (obj *ObjectBase) SetClient(c objectInterface) {
+func (obj *ObjectBase) SetClient(c ObjectInterface) {
 	obj.clientPtr = c
 }
 


### PR DESCRIPTION
This allow to implement own, custom version of all resources. This is
needed in other project to use contrail-go-api with terraform provider
for contrail generated from go templates.