### PR TITLE
Fixed one post request being sent without using the struct's http client

### DIFF
--- a/keystone.go
+++ b/keystone.go
@@ -129,7 +129,7 @@ func (kClient *KeystoneClient) AuthenticateV3() error {
 		return err
 	}
 
-	resp, err := http.Post(url, "application/json",
+	resp, err := kClient.httpClient.Post(url, "application/json",
 		bytes.NewReader(data))
 
 	if err != nil {


### PR DESCRIPTION
KeystoneClient struct has a *http.Client field. This client may have a specific configuration, e.g. TLS Transport configuration, so it should be used for all requests sent by the KeystoneClient.  